### PR TITLE
Ignore development dependencies

### DIFF
--- a/Formula/sqitch_dependencies.rb
+++ b/Formula/sqitch_dependencies.rb
@@ -18,7 +18,7 @@ class SqitchDependencies < Formula
 
     open 'META.json' do |f|
       Utils::JSON.load(f.read)['prereqs'].each do |mode, prereqs|
-       next if mode == 'test'
+        next if ['develop', 'test'].include? mode
         prereqs.each do |time, list|
           list.each do |pkg, version|
             next if pkg == 'perl'


### PR DESCRIPTION
Currently, if you `brew install sqitch_dependencies` you will get an error if you do not have all sqitch supported database clients installed.

This change does not install develop dependencies that were introduced in 0.9991 (https://github.com/theory/sqitch/commit/9e63be24da424a4f42260968e42f27cd3efed947).