### PR TITLE
Silence Homebrew deprecation warnings

### DIFF
--- a/Formula/sqitch_firebird.rb
+++ b/Formula/sqitch_firebird.rb
@@ -8,7 +8,7 @@ class SqitchFirebird < Formula
 
   # Fool brew into not downloading anything by pointing it at its own README.
   url        "file://#{HOMEBREW_REPOSITORY}/README.md", :using => :nounzip
-  sha1       Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha1
+  sha256     Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha256
 
   def install
     arch  = %x(perl -MConfig -E 'print $Config{archname}')

--- a/Formula/sqitch_mysql.rb
+++ b/Formula/sqitch_mysql.rb
@@ -8,7 +8,7 @@ class SqitchMysql < Formula
 
   # Fool brew into not downloading anything by pointing it at its own README.
   url        "file://#{HOMEBREW_REPOSITORY}/README.md", :using => :nounzip
-  sha1       Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha1
+  sha256    Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha256
 
   def install
     arch  = %x(perl -MConfig -E 'print $Config{archname}')

--- a/Formula/sqitch_oracle.rb
+++ b/Formula/sqitch_oracle.rb
@@ -7,7 +7,7 @@ class SqitchOracle < Formula
 
   # Fool brew into not downloading anything by pointing it at its own README.
   url        "file://#{HOMEBREW_REPOSITORY}/README.md", :using => :nounzip
-  sha1       Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha1
+  sha256     Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha256
 
   def install
     arch  = %x(perl -MConfig -E 'print $Config{archname}')

--- a/Formula/sqitch_pg.rb
+++ b/Formula/sqitch_pg.rb
@@ -8,7 +8,7 @@ class SqitchPg < Formula
 
   # Fool brew into not downloading anything by pointing it at its own README.
   url        "file://#{HOMEBREW_REPOSITORY}/README.md", :using => :nounzip
-  sha1       Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha1
+  sha256     Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha256
 
   def install
     arch  = %x(perl -MConfig -E 'print $Config{archname}')

--- a/Formula/sqitch_sqlite.rb
+++ b/Formula/sqitch_sqlite.rb
@@ -8,7 +8,7 @@ class SqitchSqlite < Formula
 
   # Fool brew into not downloading anything by pointing it at its own README.
   url        "file://#{HOMEBREW_REPOSITORY}/README.md", :using => :nounzip
-  sha1       Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha1
+  sha256     Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha256
 
   def install
     arch  = %x(perl -MConfig -E 'print $Config{archname}')

--- a/Formula/sqitch_vertica.rb
+++ b/Formula/sqitch_vertica.rb
@@ -8,7 +8,7 @@ class SqitchVertica < Formula
 
   # Fool brew into not downloading anything by pointing it at its own README.
   url        "file://#{HOMEBREW_REPOSITORY}/README.md", :using => :nounzip
-  sha1       Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha1
+  sha256     Pathname.new("#{HOMEBREW_REPOSITORY}/README.md").sha256
 
   def install
     arch  = %x(perl -MConfig -E 'print $Config{archname}')


### PR DESCRIPTION
Homebrew is getting more vocal about these warnings.

```
Warning: Calling Resource#sha1 is deprecated!
Use Resource#sha256 instead.
```