### PR TITLE
Add Travis-CI configuration to test homebrew package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+os: osx
+osx_image: xcode8
+before_install:
+  - brew update
+install:
+  - mkdir -p $(brew --repo)/Library/Taps/travis
+  - ln -s $PWD $(brew --repo)/Library/Taps/travis/homebrew-testtap
+  - brew tap --repair
+env:
+  - PACKAGE=sqitch BREW_AUDIT=0 BREW_TEST=0 PERL_CPANM_OPT="--skip-satisfied"
+script:
+  - if [ "$BREW_AUDIT" = 1 ]; then brew audit $PACKAGE; fi
+  - brew install -v $PACKAGE
+  - if [ "$BREW_TEST" = 1 ]; then brew test $PACKAGE; fi


### PR DESCRIPTION
Based on configuration from
<http://stackoverflow.com/questions/20396325/using-travis-ci-to-test-homebrew-tap>.

I'm currently using `cpanm`'s `--skip-satisfied` option since I had some issues with getting `Time::HiRes` to build on Travis-CI. This way it will use the version already on the system.

---

P.S. Thanks a lot for putting together this tap! I'm planning on using it as a base for an application package I'm going to release on CPAN. To see this Travis-CI configuration in action, check this [PR](https://github.com/project-renard/homebrew-project-renard/pull/2) and this [build log](https://travis-ci.org/project-renard/homebrew-project-renard/builds/161551414).

![firefox_2016-09-21_03-14-17](https://cloud.githubusercontent.com/assets/94489/18702951/8814f1ba-7fa9-11e6-961f-d2e1caa3db07.png)

Add a button:
[![Build Status](https://travis-ci.org/theory/homebrew-sqitch.svg?branch=master)](https://travis-ci.org/theory/homebrew-sqitch)

```markdown
[![Build Status](https://travis-ci.org/theory/homebrew-sqitch.svg?branch=master)](https://travis-ci.org/theory/homebrew-sqitch)
```