### PR TITLE
`Utils::load` has been depreciated in favor of `JSON::parse`

### DIFF
--- a/Formula/sqitch_dependencies.rb
+++ b/Formula/sqitch_dependencies.rb
@@ -17,7 +17,7 @@ class SqitchDependencies < Formula
     ENV.remove_from_cflags(/-msse\d?/)
 
     open 'META.json' do |f|
-      Utils::JSON.parse(f.read)['prereqs'].each do |mode, prereqs|
+      JSON.parse(f.read)['prereqs'].each do |mode, prereqs|
         next if ['develop', 'test'].include? mode
         prereqs.each do |time, list|
           list.each do |pkg, version|


### PR DESCRIPTION
fixes https://github.com/theory/homebrew-sqitch/issues/30

When it was attempted to remove the deprecation warning, it changed `Utils::JSON.load` to `Utils::JSON.parse`, but the warning message was
```
Warning: Calling Utils::JSON.load is deprecated!
Use JSON.parse instead.
```

So it should have been changed to `JSON.parse`